### PR TITLE
Allow Boolean values in UserCustomProps

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -27,7 +27,7 @@ declare global {
     }
 
     type UserCustomProps = {
-        [key: string]: string | number | Array<string> | Array<number> | UserCustomProps;
+        [key: string]: string | number | Array<string> | Array<number> | Boolean | UserCustomProps;
     }
 
     type UserGroupCustomProps = {


### PR DESCRIPTION
https://help.productfruits.com/en/article/identifying-users#custom-properties mentions boolean as valid type for the properties in the `props` field.